### PR TITLE
增强反拉回稳定性并降低发热卡顿

### DIFF
--- a/app/src/main/java/com/kail/location/service/ServiceGoNoroot.kt
+++ b/app/src/main/java/com/kail/location/service/ServiceGoNoroot.kt
@@ -70,6 +70,8 @@ class ServiceGoNoroot : Service() {
         const val DEFAULT_BEA = 0.0f
 
         private const val HANDLER_MSG_ID = 0
+        private const val LOCATION_UPDATE_INTERVAL_MS = 200L
+        private const val LOCATION_UPDATE_INTERVAL_SECONDS = LOCATION_UPDATE_INTERVAL_MS / 1000.0
         private const val SERVICE_GO_HANDLER_NAME = "ServiceGoNorootLocation"
 
         private const val SERVICE_GO_NOTE_ID = 1
@@ -494,13 +496,11 @@ class ServiceGoNoroot : Service() {
     }
 
     private fun initGoLocation() {
-        mLocHandlerThread = HandlerThread(SERVICE_GO_HANDLER_NAME, Process.THREAD_PRIORITY_FOREGROUND)
+        mLocHandlerThread = HandlerThread(SERVICE_GO_HANDLER_NAME, Process.THREAD_PRIORITY_BACKGROUND)
         mLocHandlerThread.start()
         mLocHandler = object : Handler(mLocHandlerThread.looper) {
             override fun handleMessage(msg: Message) {
                 try {
-                    Thread.sleep(50)
-
                     if (!isStop) {
                         if (mRoutePoints.size >= 2) {
                             val speedForStep = if (speedFluctuation) {
@@ -508,7 +508,7 @@ class ServiceGoNoroot : Service() {
                             } else {
                                 mSpeed
                             }
-                            advanceAlongRoute(speedForStep * 0.05)
+                            advanceAlongRoute(speedForStep * LOCATION_UPDATE_INTERVAL_SECONDS)
                             updateJoystickStatus()
                         }
                     }
@@ -518,14 +518,14 @@ class ServiceGoNoroot : Service() {
                         setLocationGPS()
                     }
 
-                    sendEmptyMessage(HANDLER_MSG_ID)
+                    sendEmptyMessageDelayed(HANDLER_MSG_ID, LOCATION_UPDATE_INTERVAL_MS)
                 } catch (e: InterruptedException) {
                     KailLog.e(this@ServiceGoNoroot, "ServiceGoNoroot", "handleMessage interrupted: ${e.message}")
                     Thread.currentThread().interrupt()
                 } catch (e: Exception) {
                     KailLog.e(this@ServiceGoNoroot, "ServiceGoNoroot", "handleMessage exception: ${e.message}")
                     if (!isStop) {
-                        sendEmptyMessageDelayed(HANDLER_MSG_ID, 100)
+                        sendEmptyMessageDelayed(HANDLER_MSG_ID, LOCATION_UPDATE_INTERVAL_MS)
                     }
                 }
             }

--- a/app/src/main/java/com/kail/location/service/ServiceGoRoot.kt
+++ b/app/src/main/java/com/kail/location/service/ServiceGoRoot.kt
@@ -77,6 +77,8 @@ class ServiceGoRoot : Service() {
         const val DEFAULT_BEA = 0.0f
 
         private const val HANDLER_MSG_ID = 0
+        private const val LOCATION_UPDATE_INTERVAL_MS = 200L
+        private const val LOCATION_UPDATE_INTERVAL_SECONDS = LOCATION_UPDATE_INTERVAL_MS / 1000.0
         private const val SERVICE_GO_HANDLER_NAME = "ServiceGoRootLocation"
 
         private const val SERVICE_GO_NOTE_ID = 1
@@ -544,13 +546,11 @@ class ServiceGoRoot : Service() {
     }
 
     private fun initGoLocation() {
-        mLocHandlerThread = HandlerThread(SERVICE_GO_HANDLER_NAME, Process.THREAD_PRIORITY_FOREGROUND)
+        mLocHandlerThread = HandlerThread(SERVICE_GO_HANDLER_NAME, Process.THREAD_PRIORITY_BACKGROUND)
         mLocHandlerThread.start()
         mLocHandler = object : Handler(mLocHandlerThread.looper) {
             override fun handleMessage(msg: Message) {
                 try {
-                    Thread.sleep(50)
-
                     if (!isStop) {
                         if (mRoutePoints.size >= 2) {
                             val speedForStep = if (speedFluctuation) {
@@ -558,7 +558,7 @@ class ServiceGoRoot : Service() {
                             } else {
                                 mSpeed
                             }
-                            advanceAlongRoute(speedForStep * 0.05)
+                            advanceAlongRoute(speedForStep * LOCATION_UPDATE_INTERVAL_SECONDS)
                             updateJoystickStatus()
                         }
                     }
@@ -567,14 +567,14 @@ class ServiceGoRoot : Service() {
                         kailTick()
                     }
 
-                    sendEmptyMessage(HANDLER_MSG_ID)
+                    sendEmptyMessageDelayed(HANDLER_MSG_ID, LOCATION_UPDATE_INTERVAL_MS)
                 } catch (e: InterruptedException) {
                     KailLog.e(this@ServiceGoRoot, "ServiceGoRoot", "handleMessage interrupted: ${e.message}")
                     Thread.currentThread().interrupt()
                 } catch (e: Exception) {
                     KailLog.e(this@ServiceGoRoot, "ServiceGoRoot", "handleMessage exception: ${e.message}")
                     if (!isStop) {
-                        sendEmptyMessageDelayed(HANDLER_MSG_ID, 100)
+                        sendEmptyMessageDelayed(HANDLER_MSG_ID, LOCATION_UPDATE_INTERVAL_MS)
                     }
                 }
             }
@@ -808,7 +808,7 @@ class ServiceGoRoot : Service() {
                 putBoolean("loopBroadcastLocation", prefs.getBoolean("setting_loop_broadcast", false))
                 putInt("minSatellites", prefs.getString("setting_min_satellites", "12")?.toIntOrNull() ?: 12)
                 putFloat("accuracy", prefs.getString("setting_accuracy", "25.0")?.toFloatOrNull() ?: 25.0f)
-                putInt("reportIntervalMs", prefs.getString("setting_report_interval", "100")?.toIntOrNull() ?: 100)
+                putInt("reportIntervalMs", (prefs.getString("setting_report_interval", "200")?.toIntOrNull() ?: 200).coerceAtLeast(200))
             }
             KailLog.i(this, "ServiceGoRoot", "pushConfigToXposed succeeded")
         } catch (e: Exception) {
@@ -839,36 +839,29 @@ class ServiceGoRoot : Service() {
         val lng = mCurLng
         val bearing = mCurBea.toDouble()
 //        KailLog.log(this, "ServiceGoRoot", "Kail Tick: lat=$lat, lng=$lng, speed=$speedToSet", isHighFrequency = true)
-// Use ThreadPool to send commands without blocking main loop
         val key = kailRandomKey ?: return
         val locMgr = mLocManager
         val provider = KAIL_PROVIDER
-        
-        Thread {
+
+        fun sendCmd(cmdId: String, block: Bundle.() -> Unit) {
             try {
-                fun sendCmd(cmdId: String, block: Bundle.() -> Unit) {
-                    try {
-                        val rely = Bundle()
-                        rely.putString("command_id", cmdId)
-                        rely.block()
-                        locMgr.sendExtraCommand(provider, key, rely)
-                    } catch (e: Exception) {
-                        // Silent fail
-                    }
-                }
-                
-                sendCmd("set_speed") { putFloat("speed", speedToSet) }
-                sendCmd("set_bearing") { putDouble("bearing", bearing) }
-                sendCmd("update_location") {
-                    putDouble("lat", lat)
-                    putDouble("lon", lng)
-                    putString("mode", "=")
-                }
-                sendCmd("broadcast_location") { }
+                val rely = Bundle()
+                rely.putString("command_id", cmdId)
+                rely.block()
+                locMgr.sendExtraCommand(provider, key, rely)
             } catch (e: Exception) {
                 // Silent fail
             }
-        }.start()
+        }
+
+        sendCmd("set_speed") { putFloat("speed", speedToSet) }
+        sendCmd("set_bearing") { putDouble("bearing", bearing) }
+        sendCmd("update_location") {
+            putDouble("lat", lat)
+            putDouble("lon", lng)
+            putString("mode", "=")
+        }
+        sendCmd("broadcast_location") { }
     }
 
     private fun kailStopSafe() {

--- a/app/src/main/java/com/kail/location/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/kail/location/viewmodels/SettingsViewModel.kt
@@ -120,7 +120,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val _minSatellites = MutableStateFlow(prefs.getString(KEY_MIN_SATELLITES, "12") ?: "12")
     val minSatellites: StateFlow<String> = _minSatellites.asStateFlow()
 
-    private val _reportInterval = MutableStateFlow(prefs.getString(KEY_REPORT_INTERVAL, "100") ?: "100")
+    private val _reportInterval = MutableStateFlow(prefs.getString(KEY_REPORT_INTERVAL, "200") ?: "200")
     val reportInterval: StateFlow<String> = _reportInterval.asStateFlow()
 
     private val _enableAGPS = MutableStateFlow(prefs.getBoolean(KEY_ENABLE_AGPS, false))
@@ -188,7 +188,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             KEY_MOCK_SPEED -> _mockSpeed.value = sharedPreferences.getString(key, "3.05") ?: "3.05"
             KEY_ACCURACY -> _accuracy.value = sharedPreferences.getString(key, "25.0") ?: "25.0"
             KEY_MIN_SATELLITES -> _minSatellites.value = sharedPreferences.getString(key, "12") ?: "12"
-            KEY_REPORT_INTERVAL -> _reportInterval.value = sharedPreferences.getString(key, "100") ?: "100"
+            KEY_REPORT_INTERVAL -> _reportInterval.value = sharedPreferences.getString(key, "200") ?: "200"
             KEY_ENABLE_AGPS -> _enableAGPS.value = sharedPreferences.getBoolean(key, false)
             KEY_ENABLE_NMEA -> _enableNMEA.value = sharedPreferences.getBoolean(key, false)
             KEY_ENABLE_MOCK_WIFI -> _enableMockWifi.value = sharedPreferences.getBoolean(key, false)
@@ -245,7 +245,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             putBoolean("loopBroadcastLocation", _loopBroadcast.value)
             putInt("minSatellites", _minSatellites.value.toIntOrNull() ?: 12)
             putFloat("accuracy", _accuracy.value.toFloatOrNull() ?: 25.0f)
-            putInt("reportIntervalMs", _reportInterval.value.toIntOrNull() ?: 100)
+            putInt("reportIntervalMs", (_reportInterval.value.toIntOrNull() ?: 200).coerceAtLeast(200))
         }
     }
 

--- a/app/src/main/java/com/kail/location/xposed/base/BaseLocationHook.kt
+++ b/app/src/main/java/com/kail/location/xposed/base/BaseLocationHook.kt
@@ -34,6 +34,12 @@ abstract class BaseLocationHook: BaseDivineService() {
         if (!FakeLoc.enable)
             return originLocation
 
+        originLocation.extras?.let {
+            if (it.getBoolean("kail_faked", false)) {
+                return originLocation
+            }
+        }
+
         if (originLocation.latitude + originLocation.longitude == FakeLoc.latitude + FakeLoc.longitude) {
             // Already processed
             return originLocation
@@ -95,6 +101,7 @@ abstract class BaseLocationHook: BaseDivineService() {
             location.extras = Bundle()
         }
         location.extras?.putDouble("latlon", location.latitude + location.longitude)
+        location.extras?.putBoolean("kail_faked", true)
         location.extras?.putInt("satellites", Random.nextInt(8, 45))
         location.extras?.putInt("maxCn0", Random.nextInt(30, 50))
         location.extras?.putInt("meanCn0", Random.nextInt(20, 30))

--- a/app/src/main/java/com/kail/location/xposed/base/BaseLocationHook.kt
+++ b/app/src/main/java/com/kail/location/xposed/base/BaseLocationHook.kt
@@ -49,7 +49,18 @@ abstract class BaseLocationHook: BaseDivineService() {
             originLocation.provider = LocationManager.GPS_PROVIDER
         }
 
-        val location = Location(originLocation.provider ?: LocationManager.GPS_PROVIDER)
+        val provider = (originLocation.provider ?: LocationManager.GPS_PROVIDER).let {
+            if (it.contains("mock", ignoreCase = true) ||
+                it.contains("test", ignoreCase = true) ||
+                it.contains("fake", ignoreCase = true)
+            ) {
+                LocationManager.GPS_PROVIDER
+            } else {
+                it
+            }
+        }
+
+        val location = Location(provider)
         location.accuracy = if (FakeLoc.accuracy != 0.0f) FakeLoc.accuracy else originLocation.accuracy
         val jitterLat = FakeLoc.jitterLocation()
         location.latitude = jitterLat.first
@@ -100,6 +111,7 @@ abstract class BaseLocationHook: BaseDivineService() {
         if (location.extras == null) {
             location.extras = Bundle()
         }
+        cleanMockExtras(location.extras)
         location.extras?.putDouble("latlon", location.latitude + location.longitude)
         location.extras?.putBoolean("kail_faked", true)
         location.extras?.putInt("satellites", Random.nextInt(8, 45))
@@ -118,6 +130,7 @@ abstract class BaseLocationHook: BaseDivineService() {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 location.isMock = false
             }
+            cleanMockFields(location)
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 location.isMock = true
@@ -139,6 +152,23 @@ abstract class BaseLocationHook: BaseDivineService() {
         return location
         } finally {
             injecting.set(false)
+        }
+    }
+
+    private fun cleanMockExtras(extras: Bundle?) {
+        extras ?: return
+        extras.remove("mockLocation")
+        extras.remove("isMock")
+        extras.remove("is_mock")
+        extras.remove("mock")
+    }
+
+    private fun cleanMockFields(location: Location) {
+        kotlin.runCatching {
+            XposedHelpers.setBooleanField(location, "mMock", false)
+        }
+        kotlin.runCatching {
+            XposedHelpers.setBooleanField(location, "mIsFromMockProvider", false)
         }
     }
 

--- a/app/src/main/java/com/kail/location/xposed/core/KailCommandHandler.kt
+++ b/app/src/main/java/com/kail/location/xposed/core/KailCommandHandler.kt
@@ -189,8 +189,8 @@ internal object KailCommandHandler {
                     out.getBoolean("loopBroadcastLocation", FakeLoc.loopBroadcastLocation).let { FakeLoc.loopBroadcastLocation = it }
                     out.getInt("minSatellites", FakeLoc.minSatellites).let { FakeLoc.minSatellites = it }
                     out.getFloat("accuracy", FakeLoc.accuracy).let { FakeLoc.accuracy = it }
-                    out.getInt("reportIntervalMs", 100).let {
-                        FakeLoc.reportIntervalMs = it
+                    out.getInt("reportIntervalMs", 200).let {
+                        FakeLoc.reportIntervalMs = it.coerceAtLeast(200)
                     }
                     out.putBoolean("ok", true)
                     KailLog.d(null, "XPOSED", "KAIL接收：批量配置更新")

--- a/app/src/main/java/com/kail/location/xposed/hooks/LocationManagerHook.kt
+++ b/app/src/main/java/com/kail/location/xposed/hooks/LocationManagerHook.kt
@@ -28,7 +28,7 @@ object LocationManagerHook: BaseLocationHook() {
             }
         }
         if(cLocationManager.declaredMethods.filter {
-            it.name == "getLastKnownLocation" && it.parameterTypes.size > 1
+            it.name == "getLastKnownLocation"
         }.map {
             XposedBridge.hookMethod(it, hookGetLastKnownLocation)
         }.isEmpty()) {

--- a/app/src/main/java/com/kail/location/xposed/hooks/LocationServiceHook.kt
+++ b/app/src/main/java/com/kail/location/xposed/hooks/LocationServiceHook.kt
@@ -311,6 +311,23 @@ private val gnssPushRunnable = object : Runnable {
 
 internal object LocationServiceHook: BaseLocationHook() {
     val locationListeners = LinkedBlockingQueue<Pair<String, IInterface>>()
+    private var pullbackPushStarted = false
+    private val pullbackPushHandler: Handler by lazy {
+        val thread = HandlerThread("KailPullbackPusher").apply { start() }
+        Handler(thread.looper)
+    }
+    private val pullbackPushRunnable = object : Runnable {
+        override fun run() {
+            if (FakeLoc.enable && FakeLoc.loopBroadcastLocation && locationListeners.isNotEmpty()) {
+                kotlin.runCatching {
+                    callOnLocationChanged()
+                }.onFailure {
+                    KailLog.e(null, "Kail_Xposed", "Pullback broadcast failed: ${it.message}")
+                }
+            }
+            pullbackPushHandler.postDelayed(this, FakeLoc.reportIntervalMs.coerceAtLeast(200).toLong())
+        }
+    }
 
     // A random command is generated to prevent some apps from detecting Kail
     operator fun invoke(classLoader: ClassLoader) {
@@ -320,7 +337,7 @@ internal object LocationServiceHook: BaseLocationHook() {
         } else {
             onService(cLocationManagerService)
         }
-        //startDaemon(classLoader)
+        ensurePullbackPushStarted()
     }
 
     fun onService(cILocationManager: Class<*>) {
@@ -772,13 +789,30 @@ internal object LocationServiceHook: BaseLocationHook() {
 //        })
 
         cILocationManager.hookAllMethods("getCurrentLocation", beforeHook {
-            val callback = args[2] ?: return@beforeHook
+            if (!FakeLoc.enable) return@beforeHook
+            val callback = args.firstOrNull { arg ->
+                arg != null && arg.javaClass.methods.any { it.name == "onLocation" && it.parameterTypes.size == 1 }
+            } ?: return@beforeHook
 
             if (FakeLoc.enableDebugLog) {
                 KailLog.d(null, "Kail_Xposed", "getCurrentLocation: injected!")
             }
 
-            if (FakeLoc.disableGetCurrentLocation) {
+            val fakeLocation = injectLocation((FakeLoc.lastLocation ?: Location("gps")).apply {
+                if (time <= 0L) time = System.currentTimeMillis()
+                if (elapsedRealtimeNanos <= 0L) elapsedRealtimeNanos = System.nanoTime()
+            }, false)
+
+            val fulfilled = kotlin.runCatching {
+                val onLocation = callback.javaClass.methods.firstOrNull {
+                    it.name == "onLocation" && it.parameterTypes.size == 1
+                } ?: return@runCatching false
+                onLocation.isAccessible = true
+                onLocation.invoke(callback, fakeLocation)
+                true
+            }.getOrDefault(false)
+
+            if (fulfilled || FakeLoc.disableGetCurrentLocation) {
                 result = null
                 return@beforeHook
             }
@@ -962,7 +996,14 @@ internal object LocationServiceHook: BaseLocationHook() {
 //        }
 //    }
 
+    private fun ensurePullbackPushStarted() {
+        if (pullbackPushStarted) return
+        pullbackPushStarted = true
+        pullbackPushHandler.post(pullbackPushRunnable)
+    }
+
     private fun addLocationListenerInner(provider: String, listener: IInterface) {
+        val binder = listener.asBinder()
         val mDeathRecipient = object: IBinder.DeathRecipient {
             override fun binderDied() {}
             override fun binderDied(who: IBinder) {
@@ -970,9 +1011,15 @@ internal object LocationServiceHook: BaseLocationHook() {
                 removeLocationListenerByBinder(who)
             }
         }
-        listener.asBinder().linkToDeath(mDeathRecipient, 0)
-        locationListeners.add(provider to listener)
+        kotlin.runCatching { binder.linkToDeath(mDeathRecipient, 0) }
+        if (locationListeners.none { it.second.asBinder() == binder }) {
+            locationListeners.add(provider to listener)
+        }
         hookILocationListener(listener)
+        ensurePullbackPushStarted()
+        if (FakeLoc.enable) {
+            callOnLocationChanged()
+        }
     }
 
     private fun removeLocationListenerInner(listener: IInterface) {

--- a/app/src/main/java/com/kail/location/xposed/utils/FakeLoc.kt
+++ b/app/src/main/java/com/kail/location/xposed/utils/FakeLoc.kt
@@ -19,7 +19,7 @@ object FakeLoc {
     /**
      * 是否允许打印调试日志
      */
-    var enableDebugLog = true
+    var enableDebugLog = false
 
     /**
      * 模拟定位服务开关
@@ -98,7 +98,7 @@ object FakeLoc {
     /**
      * 位置上报间隔（毫秒），仅用于部分需要控制频率的场景
      */
-    var reportIntervalMs = 100
+    var reportIntervalMs = 200
 
     /**
      * 上一次的位置

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -359,7 +359,7 @@
     <string name="setting_min_satellites">Min Satellite Count</string>
     <string name="setting_min_satellites_summary">BeiDou satellites only</string>
     <string name="setting_report_interval">Report Interval (ms)</string>
-    <string name="setting_report_interval_summary">In milliseconds, default 100ms</string>
+    <string name="setting_report_interval_summary">In milliseconds, default 200ms; values below 200ms are clamped to 200ms</string>
     <string name="setting_gps_satellite_title">Simulate GPS Satellite Signal</string>
     <string name="setting_gps_satellite_summary">Forge BeiDou satellite count and signal strength</string>
     <string name="setting_agps_title">Enable AGPS Module</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -321,7 +321,7 @@
     <string name="setting_min_satellites">最小シミュレート衛星数</string>
     <string name="setting_min_satellites_summary">BeiDou 衛星のみ対応</string>
     <string name="setting_report_interval">報告間隔 (ms)</string>
-    <string name="setting_report_interval_summary">ミリ秒単位、既定は 100ms</string>
+    <string name="setting_report_interval_summary">ミリ秒単位、既定は 200ms。200ms 未満は 200ms として処理されます</string>
     <string name="setting_gps_satellite_title">GPS 衛星信号をシミュレート</string>
     <string name="setting_gps_satellite_summary">BeiDou 衛星数と信号強度を偽装します</string>
     <string name="setting_agps_title">AGPS モジュールを有効にする</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -321,7 +321,7 @@
     <string name="setting_min_satellites">最少模擬衛星數量</string>
     <string name="setting_min_satellites_summary">僅支援北斗衛星</string>
     <string name="setting_report_interval">回報間隔 (ms)</string>
-    <string name="setting_report_interval_summary">以毫秒為單位，預設 100ms</string>
+    <string name="setting_report_interval_summary">以毫秒為單位，預設 200ms，低於 200ms 會按 200ms 處理</string>
     <string name="setting_gps_satellite_title">模擬 GPS 衛星訊號</string>
     <string name="setting_gps_satellite_summary">偽造北斗衛星數量與訊號強度</string>
     <string name="setting_agps_title">啟用 AGPS 模組</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -324,7 +324,7 @@
     <string name="setting_min_satellites">最少模擬衛星數量</string>
     <string name="setting_min_satellites_summary">僅支援北斗衛星</string>
     <string name="setting_report_interval">回報間隔 (ms)</string>
-    <string name="setting_report_interval_summary">以毫秒為單位，預設 100ms</string>
+    <string name="setting_report_interval_summary">以毫秒為單位，預設 200ms，低於 200ms 會按 200ms 處理</string>
     <string name="setting_gps_satellite_title">模擬 GPS 衛星訊號</string>
     <string name="setting_gps_satellite_summary">偽造北斗衛星數量與訊號強度</string>
     <string name="setting_agps_title">啟用 AGPS 模組</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -370,7 +370,7 @@
     <string name="setting_min_satellites">最少模拟卫星数量</string>
     <string name="setting_min_satellites_summary">仅支持北斗卫星</string>
     <string name="setting_report_interval">上报位置频率 (ms)</string>
-    <string name="setting_report_interval_summary">单位毫秒，默认 100ms</string>
+    <string name="setting_report_interval_summary">单位毫秒，默认 200ms，低于 200ms 会按 200ms 处理</string>
     <string name="setting_gps_satellite_title">模拟 GPS 卫星信号</string>
     <string name="setting_gps_satellite_summary">伪造北斗卫星数量和信号强度</string>
     <string name="setting_agps_title">启用 AGPS 模块</string>


### PR DESCRIPTION
## 概述

这个 PR 主要增强虚拟定位的反拉回稳定性，并降低后台模拟定位时的功耗和发热，代码借助GPT5.5编写，有构建成apk进行实机测试并没有发生拉回真实位置的现象了

## 改动内容

- 为注入的虚拟定位增加标记，避免重复抖动处理。
- 改进 `getLastKnownLocation` 的 Hook 覆盖范围。
- 当应用注册定位监听器时，立即推送一次虚拟定位。
- 对 `getCurrentLocation` 回调立即返回虚拟定位。
- 增加轻量级周期推送，降低被拉回真实定位的概率。
- 将 Root/NoRoot 服务循环间隔从 50ms 调整为 200ms。
- 避免 Root 服务每次 tick 都创建新线程。
- 将 HandlerThread 优先级从前台降为后台。
- 默认关闭调试日志。
- 将默认/最小上报间隔调整为 200ms。

## 修改动机
开启反定位拉回后，还是偶尔会被拉回真实位置，长时间定位会造成发热卡死