### PR TITLE
隐藏 mock provider 痕迹

### DIFF
--- a/app/src/main/java/com/kail/location/xposed/base/BaseLocationHook.kt
+++ b/app/src/main/java/com/kail/location/xposed/base/BaseLocationHook.kt
@@ -43,7 +43,18 @@ abstract class BaseLocationHook: BaseDivineService() {
             originLocation.provider = LocationManager.GPS_PROVIDER
         }
 
-        val location = Location(originLocation.provider ?: LocationManager.GPS_PROVIDER)
+        val provider = (originLocation.provider ?: LocationManager.GPS_PROVIDER).let {
+            if (it.contains("mock", ignoreCase = true) ||
+                it.contains("test", ignoreCase = true) ||
+                it.contains("fake", ignoreCase = true)
+            ) {
+                LocationManager.GPS_PROVIDER
+            } else {
+                it
+            }
+        }
+
+        val location = Location(provider)
         location.accuracy = if (FakeLoc.accuracy != 0.0f) FakeLoc.accuracy else originLocation.accuracy
         val jitterLat = FakeLoc.jitterLocation()
         location.latitude = jitterLat.first
@@ -94,6 +105,7 @@ abstract class BaseLocationHook: BaseDivineService() {
         if (location.extras == null) {
             location.extras = Bundle()
         }
+        cleanMockExtras(location.extras)
         location.extras?.putDouble("latlon", location.latitude + location.longitude)
         location.extras?.putInt("satellites", Random.nextInt(8, 45))
         location.extras?.putInt("maxCn0", Random.nextInt(30, 50))
@@ -111,6 +123,7 @@ abstract class BaseLocationHook: BaseDivineService() {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 location.isMock = false
             }
+            cleanMockFields(location)
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 location.isMock = true
@@ -132,6 +145,23 @@ abstract class BaseLocationHook: BaseDivineService() {
         return location
         } finally {
             injecting.set(false)
+        }
+    }
+
+    private fun cleanMockExtras(extras: Bundle?) {
+        extras ?: return
+        extras.remove("mockLocation")
+        extras.remove("isMock")
+        extras.remove("is_mock")
+        extras.remove("mock")
+    }
+
+    private fun cleanMockFields(location: Location) {
+        kotlin.runCatching {
+            XposedHelpers.setBooleanField(location, "mMock", false)
+        }
+        kotlin.runCatching {
+            XposedHelpers.setBooleanField(location, "mIsFromMockProvider", false)
         }
     }
 


### PR DESCRIPTION
隐藏 mock provider 痕迹
主要是把注入位置里的 mock 标记和相关内部字段处理掉